### PR TITLE
Fran branch

### DIFF
--- a/components/Elements/General/Modal/ModalShare.tsx
+++ b/components/Elements/General/Modal/ModalShare.tsx
@@ -5,7 +5,7 @@ import Button from "@/components/Reusable/Button";
 interface ShareModalProps {
   isOpen: boolean;
   onClose: () => void;
-  shareCode: string;
+  shareCode?: string;
 }
 
 export default function ShareModal({ isOpen, onClose, shareCode }: ShareModalProps) {

--- a/components/Pages/(Nav & Top)/Pomodoro/Timer.tsx
+++ b/components/Pages/(Nav & Top)/Pomodoro/Timer.tsx
@@ -8,15 +8,15 @@ import TypeTimeButtons from "../../../Elements/Pomodoro/TypeTimeButtons";
 import Commands from "@/components/Elements/Pomodoro/Commands";
 import { chipsIconType } from "@/components/Reusable/Chips";
 import { SocketIOContext } from "@/components/Provider/WebsocketProvider";
-import { toast } from "react-hot-toast";
+// import { toast } from "react-hot-toast";
 import ShareModal from '@/components/Elements/General/Modal/ModalShare';
 
-export default function Timer({ token }: { token: string }) {
+export default function Timer(/*{ token }: { token: string }*/) {
   const [menu, setMenu] = useState<chipsIconType>("concentracion");
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [pomodoroId, setPomodoroId] = useState<string | null>(null);
   const [shareModalOpen, setShareModalOpen] = useState(false);
-  const [shareCode, setShareCode] = useState('');
+  // const [shareCode, setShareCode] = useState('');
 
   const { setTime, time, setInitialTime, initialTime, toggleChronometerMode } =
     useContext(TimerContext);
@@ -148,36 +148,36 @@ export default function Timer({ token }: { token: string }) {
     setInitialTime(menuTimes[menu as keyof typeof menuTimes]);
   }, [pomodoroId, stopPomodoro, menu, menuTimes, setTime, setInitialTime]);
 
-  const handleShare = useCallback(async () => {
-    if (!pomodoroId) {
-      toast.error("No hay un pomodoro activo para compartir");
-      return;
-    }
+  // const handleShare = useCallback(async () => {
+  //   if (!pomodoroId) {
+  //     toast.error("No hay un pomodoro activo para compartir");
+  //     return;
+  //   }
     
-    try {
-      const response = await fetch(`/api/v0/pomodoro/${pomodoroId}/share`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`
-        }
-      });
+  //   try {
+  //     const response = await fetch(`/api/v0/pomodoro/${pomodoroId}/share`, {
+  //       method: 'POST',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //         'Authorization': `Bearer ${token}`
+  //       }
+  //     });
       
-      if (!response.ok) {
-        throw new Error(`Error: ${response.status}`);
-      }
+  //     if (!response.ok) {
+  //       throw new Error(`Error: ${response.status}`);
+  //     }
       
-      const data = await response.json();
+  //     const data = await response.json();
       
-      if (data.shareCode) {
-        setShareCode(data.shareCode);
-        setShareModalOpen(true);
-      }
-    } catch (error) {
-      console.error("Error al compartir pomodoro:", error);
-      toast.error("No se pudo compartir el pomodoro");
-    }
-  }, [pomodoroId, token]);
+  //     if (data.shareCode) {
+  //       setShareCode(data.shareCode);
+  //       setShareModalOpen(true);
+  //     }
+  //   } catch (error) {
+  //     console.error("Error al compartir pomodoro:", error);
+  //     toast.error("No se pudo compartir el pomodoro");
+  //   }
+  // }, [pomodoroId, token]);
 
   const handleClick = useCallback(
     (id: string) => {
@@ -188,12 +188,12 @@ export default function Timer({ token }: { token: string }) {
         case "reset":
           handleReset();
           break;
-        case "share":
-          handleShare();
+        // case "share":
+        //   handleShare();
           break;
       }
     },
-    [handleTogglePlay, handleReset, handleShare]
+    [handleTogglePlay, handleReset]
   );
 
   const renderDigits = (num: number) =>
@@ -258,7 +258,7 @@ export default function Timer({ token }: { token: string }) {
       <ShareModal 
         isOpen={shareModalOpen} 
         onClose={() => setShareModalOpen(false)} 
-        shareCode={shareCode} 
+        // shareCode={shareCode} 
       />
     </>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-hot-toast:
-        specifier: ^2.5.2
-        version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       resend:
         specifier: ^4.3.0
         version: 4.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1194,11 +1191,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  goober@2.1.16:
-    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
-    peerDependencies:
-      csstype: ^3.0.10
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1682,13 +1674,6 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
-
-  react-hot-toast@2.5.2:
-    resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: '>=16'
-      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -3222,10 +3207,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  goober@2.1.16(csstype@3.1.3):
-    dependencies:
-      csstype: 3.1.3
-
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -3695,13 +3676,6 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
-
-  react-hot-toast@2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      csstype: 3.1.3
-      goober: 2.1.16(csstype@3.1.3)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
This pull request includes changes to refactor the `Timer` component in the Pomodoro feature, adjust the `ShareModal` component, and remove unused dependencies from the `pnpm-lock.yaml` file. The most significant updates involve commenting out unused functionality, modifying type definitions, and cleaning up the dependency tree.

### Refactoring and commenting out unused functionality:

* The `Timer` component has been updated to comment out the `handleShare` function and its associated logic, including the `shareCode` state and its usage in the `ShareModal` component. This is likely a temporary measure to disable the sharing functionality. (`components/Pages/(Nav & Top)/Pomodoro/Timer.tsx`, [[1]](diffhunk://#diff-ec0a4629001cd47aafc9dac46bf302fe20749b8663b9fce3fb806fafb1067859L11-R19) [[2]](diffhunk://#diff-ec0a4629001cd47aafc9dac46bf302fe20749b8663b9fce3fb806fafb1067859L154-R184) [[3]](diffhunk://#diff-ec0a4629001cd47aafc9dac46bf302fe20749b8663b9fce3fb806fafb1067859L188-R200) [[4]](diffhunk://#diff-ec0a4629001cd47aafc9dac46bf302fe20749b8663b9fce3fb806fafb1067859L258-R265)

### Type adjustments:

* The `shareCode` property in the `ShareModalProps` interface is now optional (`shareCode?: string`) to reflect its conditional usage. (`components/Elements/General/Modal/ModalShare.tsx`, [components/Elements/General/Modal/ModalShare.tsxL8-R8](diffhunk://#diff-f0589d7c422d7cf8399587c0695b7fc2c1503d84dbe6b8d2ba1aa7da48da0c1fL8-R8))

### Dependency cleanup:

* Removed the `react-hot-toast` and `goober` dependencies from `pnpm-lock.yaml`, indicating these libraries are no longer in use. (`pnpm-lock.yaml`, [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-L31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1197-L1201) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1686-L1692) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3225-L3228) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3699-L3705)